### PR TITLE
Allow for setting use_oauth_2 on creation to use oauth2 endpoint

### DIFF
--- a/flair_api/client.py
+++ b/flair_api/client.py
@@ -163,7 +163,9 @@ class Client(object):
                  mapper={},
                  admin=False,
                  default_model=Resource,
-                 timeout=5.0):
+                 timeout=5.0,
+                 use_oauth_2=False):
+        self.use_oauth_2 = use_oauth_2
         self.admin = admin
         self.client_id = client_id
         self.client_secret = client_secret
@@ -176,7 +178,8 @@ class Client(object):
         return urljoin(self.api_root, path)
 
     def oauth_token(self):
-        resp = requests.post(self.create_url("/oauth/token"), data=dict(
+        oauth_url = "/oauth2/token" if self.use_oauth_2 else "/oauth/token"
+        resp = requests.post(self.create_url(oauth_url), data=dict(
             client_id=self.client_id,
             client_secret=self.client_secret,
             grant_type="client_credentials"
@@ -337,13 +340,14 @@ class Client(object):
             return body
 
 
-def make_client(client_id, client_secret, root, mapper={}, admin=False):
+def make_client(client_id, client_secret, root, mapper={}, admin=False, use_oauth_2=False):
     c = Client(
        client_id=client_id,
        client_secret=client_secret,
        api_root=root,
        mapper=mapper,
-       admin=admin
+       admin=admin,
+       use_oauth_2=use_oauth_2
     )
     c.oauth_token()
     c.api_root_response()


### PR DESCRIPTION
Resolves #7 

Add a tracked parameter for use_oauth_2, default = False so that this won't regress any existing implementations.

Testing:

Manually tested with oauth 1 and 2 keys, with and without the flag, and was able to authenticate and get token using `make_client` for both.